### PR TITLE
Try to make models more deterministic

### DIFF
--- a/lib/Model.ml
+++ b/lib/Model.ml
@@ -14,13 +14,17 @@ let rec value_of (model : t) (var : string) : Value.t =
        ^ " in this model")
   | Some ((x, v) :: t) -> if x == var then v else value_of (Some t) var
 
-let to_string (model : t) : string =
+let pp (fmt : Format.formatter) (model : t) : unit =
+  let open Format in
   match model with
-  | None -> "No model"
-  | Some [] -> "Empty model"
+  | None -> pp_print_string fmt "No model"
+  | Some [] -> pp_print_string fmt "Empty model"
   | Some m ->
-      "\n\t\t\t\t"
-      ^ String.concat "\n\t\t\t\t"
-          (List.map (fun (x, v) -> Format.asprintf "%s : %a" x Value.pp v) m)
+      let m = List.sort (fun (x1, _) (x2, _) -> String.compare x1 x2) m in
+      pp_print_list
+        ~pp_sep:(fun fmt () -> fprintf fmt "@\n")
+        (fun fmt (x, v) -> fprintf fmt "%s : %a" x Value.pp v)
+        fmt m
 
-let print (model : t) : unit = to_string model |> print_endline
+let to_string (model : t) : string = Format.asprintf "%a" pp model
+let print (model : t) : unit = Format.printf "%a@." pp model

--- a/lib/Outcome.ml
+++ b/lib/Outcome.ml
@@ -5,15 +5,18 @@ type t =
   | Error of Model.t
   | EndGas
 
-let to_string (o : t) : string =
-  match o with
-  | Cont _ -> "Continue"
-  | Error e -> "Assertion violated, counter example:" ^ Model.to_string e
-  | AssumeF -> "Assumption evaluated to false"
-  | Return e -> "Returned " ^ e
-  | EndGas -> "EndGas"
+let pp fmt = function
+  | Cont _ -> Format.pp_print_string fmt "Continue"
+  | Error e ->
+      Format.fprintf fmt
+        "Assertion violated, counter example:@\n@[<v 4>    %a@]" Model.pp e
+  | AssumeF -> Format.pp_print_string fmt "Assumption evaluated to false"
+  | Return e -> Format.fprintf fmt "Returned %s" e
+  | EndGas -> Format.pp_print_string fmt "EndGas"
+
+let to_string (o : t) : string = Format.asprintf "%a" pp o
 
 let should_halt (o : t) : bool =
   match o with Error _ | AssumeF | EndGas -> true | _ -> false
 
-let print (o : t) : unit = to_string o |> print_endline
+let print (o : t) : unit = Format.printf "%a@." pp o

--- a/lib/Outcome.ml
+++ b/lib/Outcome.ml
@@ -5,18 +5,17 @@ type t =
   | Error of Model.t
   | EndGas
 
-let pp fmt = function
+let pp ?(no_values = false) fmt = function
   | Cont _ -> Format.pp_print_string fmt "Continue"
   | Error e ->
       Format.fprintf fmt
-        "Assertion violated, counter example:@\n@[<v 4>    %a@]" Model.pp e
+        "Assertion violated, counter example:@\n@[<v 4>    %a@]"
+        (Model.pp ~no_values) e
   | AssumeF -> Format.pp_print_string fmt "Assumption evaluated to false"
   | Return e -> Format.fprintf fmt "Returned %s" e
   | EndGas -> Format.pp_print_string fmt "EndGas"
 
-let to_string (o : t) : string = Format.asprintf "%a" pp o
+let to_string (o : t) : string = Format.asprintf "%a" (pp ~no_values:false) o
 
 let should_halt (o : t) : bool =
   match o with Error _ | AssumeF | EndGas -> true | _ -> false
-
-let print (o : t) : unit = Format.printf "%a@." pp o

--- a/lib/Value.ml
+++ b/lib/Value.ml
@@ -1,10 +1,17 @@
 type t = Integer of int | Boolean of bool | Loc of int | Error
 
-let pp fmt (v : t) =
+let pp ?(no_values = false) fmt (v : t) =
+  let open Format in
   match v with
-  | Integer n -> Format.fprintf fmt "Int %d" n
-  | Boolean b -> Format.fprintf fmt "Bool %b" b
-  | Loc l -> Format.fprintf fmt "Loc %d" l
-  | Error -> Format.pp_print_string fmt "Error"
+  | Integer n ->
+     if no_values then fprintf fmt "Int _"
+     else fprintf fmt "Int %d" n
+  | Boolean b ->
+    if no_values then fprintf fmt "Bool _ "
+    else fprintf fmt "Bool %b" b
+  | Loc l ->
+    if no_values then fprintf fmt "Loc _ "
+    else fprintf fmt "Loc %d" l
+  | Error -> pp_print_string fmt "Error"
 
-let to_string = Format.asprintf "%a" pp
+let to_string = Format.asprintf "%a" (pp ~no_values:false)

--- a/lib/log.ml
+++ b/lib/log.ml
@@ -1,0 +1,1 @@
+let error fmt = Format.kasprintf failwith fmt

--- a/lib/model.ml
+++ b/lib/model.ml
@@ -2,17 +2,21 @@ type t = (string * Value.t) list option
 
 let empty = Some []
 
-let rec value_of (model : t) (var : string) : Value.t =
+let get_value (model : t) (var : string) : Value.t =
   match model with
   | None ->
-      failwith
-        ("InternalError: Model.value_of, tried to get the value of variable "
-       ^ var ^ " with a None model")
-  | Some [] ->
-      invalid_arg
-        ("InternalError: Model.value_of, there is no variable with name " ^ var
-       ^ " in this model")
-  | Some ((x, v) :: t) -> if x == var then v else value_of (Some t) var
+      Log.error
+        "InternalError: Model.value_of, tried to get the value of variable %s \
+         with a None model"
+        var
+  | Some model -> (
+      match List.assoc var model with
+      | exception Not_found ->
+          Log.error
+            "InternalError: Model.value_of, there is no variable with name %s \
+             in this model"
+            var
+      | v -> v)
 
 let pp (fmt : Format.formatter) (model : t) : unit =
   let open Format in
@@ -27,4 +31,3 @@ let pp (fmt : Format.formatter) (model : t) : unit =
         fmt m
 
 let to_string (model : t) : string = Format.asprintf "%a" pp model
-let print (model : t) : unit = Format.printf "%a@." pp model

--- a/lib/model.ml
+++ b/lib/model.ml
@@ -18,16 +18,17 @@ let get_value (model : t) (var : string) : Value.t =
             var
       | v -> v)
 
-let pp (fmt : Format.formatter) (model : t) : unit =
+let pp ?(no_values = false) (fmt : Format.formatter) (model : t) : unit =
   let open Format in
+  let pp_binding fmt (x, v) =
+    Format.fprintf fmt "%s : %a" x (Value.pp ~no_values) v
+  in
   match model with
   | None -> pp_print_string fmt "No model"
   | Some [] -> pp_print_string fmt "Empty model"
   | Some m ->
       let m = List.sort (fun (x1, _) (x2, _) -> String.compare x1 x2) m in
-      pp_print_list
-        ~pp_sep:(fun fmt () -> fprintf fmt "@\n")
-        (fun fmt (x, v) -> fprintf fmt "%s : %a" x Value.pp v)
-        fmt m
+      pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt "@\n") pp_binding fmt m
 
-let to_string (model : t) : string = Format.asprintf "%a" pp model
+let to_string (model : t) : string =
+  Format.asprintf "%a" (pp ~no_values:false) model

--- a/lib/model.mli
+++ b/lib/model.mli
@@ -2,5 +2,5 @@ type t = (string * Value.t) list option
 
 val empty : t
 val get_value : t -> string -> Value.t
-val pp : Format.formatter -> t -> unit
+val pp : ?no_values:bool -> Format.formatter -> t -> unit
 val to_string : t -> string

--- a/lib/model.mli
+++ b/lib/model.mli
@@ -1,0 +1,6 @@
+type t = (string * Value.t) list option
+
+val empty : t
+val get_value : t -> string -> Value.t
+val pp : Format.formatter -> t -> unit
+val to_string : t -> string

--- a/lib/term.ml
+++ b/lib/term.ml
@@ -98,7 +98,7 @@ let rec pp fmt (e : t) =
   | B_symb s -> fprintf fmt "(SymbBool %s)" s
   | I_symb s -> fprintf fmt "(SymbInt %s)" s
   | Var x -> fprintf fmt "(Var %s)" x
-  | Val v -> fprintf fmt "(Val %a)" Value.pp v
+  | Val v -> fprintf fmt "(Val %a)" (Value.pp ~no_values:false) v
   | Unop (op, v) -> fprintf fmt "(%a %a)" pp_unop op pp v
   | Binop (op, v1, v2) -> fprintf fmt "(%a %a %a)" pp_binop op pp v1 pp v2
   | Ite (e1, e2, e3) -> fprintf fmt "(%a %a %a)" pp e1 pp e2 pp e3

--- a/test/basic/tree/3.wl
+++ b/test/basic/tree/3.wl
@@ -1,5 +1,4 @@
-function aenima() {    
-
+function aenima() {
     i = symbol_int("i");
     j = symbol_int("j");
     k = symbol_int("k");
@@ -13,6 +12,8 @@ function aenima() {
     assume(k<8);
 
     v = symbol_int("v");
+    assume(v != 0);
+    assume(v != 42);
 
     x = new(8);
 

--- a/test/script.ml
+++ b/test/script.ml
@@ -41,22 +41,22 @@ let run model file =
   | "saf" ->
       let rets = SAF.interpret program in
       List.iter
-        (fun (out, _) -> Format.printf "Outcome: %s@." (Outcome.to_string out))
+        (fun (out, _) -> Format.printf "Outcome: %a@." Outcome.pp out)
         rets
   | "saite" ->
       let rets = SAITE.interpret program in
       List.iter
-        (fun (out, _) -> Format.printf "Outcome: %s@." (Outcome.to_string out))
+        (fun (out, _) -> Format.printf "Outcome: %a@." Outcome.pp out)
         rets
   | "st" ->
       let rets = ST.interpret program in
       List.iter
-        (fun (out, _) -> Format.printf "Outcome: %s@." (Outcome.to_string out))
+        (fun (out, _) -> Format.printf "Outcome: %a@." Outcome.pp out)
         rets
   | "sopl" ->
       let rets = SOPL.interpret program in
       List.iter
-        (fun (out, _) -> Format.printf "Outcome: %s@." (Outcome.to_string out))
+        (fun (out, _) -> Format.printf "Outcome: %a@." Outcome.pp out)
         rets
   | _ -> assert false
 

--- a/test/script.ml
+++ b/test/script.ml
@@ -41,22 +41,26 @@ let run model file =
   | "saf" ->
       let rets = SAF.interpret program in
       List.iter
-        (fun (out, _) -> Format.printf "Outcome: %a@." Outcome.pp out)
+        (fun (out, _) ->
+          Format.printf "Outcome: %a@." (Outcome.pp ~no_values:true) out)
         rets
   | "saite" ->
       let rets = SAITE.interpret program in
       List.iter
-        (fun (out, _) -> Format.printf "Outcome: %a@." Outcome.pp out)
+        (fun (out, _) ->
+          Format.printf "Outcome: %a@." (Outcome.pp ~no_values:true) out)
         rets
   | "st" ->
       let rets = ST.interpret program in
       List.iter
-        (fun (out, _) -> Format.printf "Outcome: %a@." Outcome.pp out)
+        (fun (out, _) ->
+          Format.printf "Outcome: %a@." (Outcome.pp ~no_values:true) out)
         rets
   | "sopl" ->
       let rets = SOPL.interpret program in
       List.iter
-        (fun (out, _) -> Format.printf "Outcome: %a@." Outcome.pp out)
+        (fun (out, _) ->
+          Format.printf "Outcome: %a@." (Outcome.pp ~no_values:true) out)
         rets
   | _ -> assert false
 

--- a/test/test_saf.t
+++ b/test/test_saf.t
@@ -12,7 +12,7 @@ Tests Model ArrayFork:
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 3
+      $_i : Int 3
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   
@@ -24,29 +24,29 @@ Tests Model ArrayFork:
   Execution mode: saf
   
   Outcome: Assertion violated, counter example:
-  				$_i : Int 0
-  				$_v : Int 0
+      $_i : Int 0
+      $_v : Int 0
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 1
-  				$_v : Int 1
+      $_i : Int 1
+      $_v : Int 1
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 2
-  				$_v : Int 2
+      $_i : Int 2
+      $_v : Int 2
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 3
-  				$_v : Int 3
+      $_i : Int 3
+      $_v : Int 3
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -373,7 +373,8 @@ Tests Model ArrayFork:
   Input file: basic/common/3.wl
   Execution mode: saf
   
-  Outcome: Assertion violated, counter example:Empty model
+  Outcome: Assertion violated, counter example:
+      Empty model
   
   =====================
   	Ænima
@@ -409,7 +410,8 @@ Tests Model ArrayFork:
   Input file: basic/common/6.wl
   Execution mode: saf
   
-  Outcome: Assertion violated, counter example:Empty model
+  Outcome: Assertion violated, counter example:
+      Empty model
   
   =====================
   	Ænima
@@ -501,10 +503,10 @@ Tests Model ArrayFork:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 22
+      $_i : Int 22
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int -158
+      $_i : Int -158
   
   =====================
   	Ænima
@@ -3086,78 +3088,71 @@ Tests Model ArrayFork:
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
-  Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_j : Int 0
-  				$_i : Int 5
-  				$_v : Int 2
-  				$_k : Int 5
-  Outcome: Returned (Val Loc 0)
+      $_i : Int 5
+      $_j : Int 0
+      $_k : Int 5
+      $_v : Int 2
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_v : Int 2
-  				$_k : Int 5
-  				$_i : Int 5
-  				$_j : Int 1
-  Outcome: Returned (Val Loc 0)
+      $_i : Int 5
+      $_j : Int 1
+      $_k : Int 5
+      $_v : Int 2
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 5
-  				$_k : Int 5
-  				$_j : Int 2
-  				$_v : Int 3
-  Outcome: Returned (Val Loc 0)
+      $_i : Int 5
+      $_j : Int 2
+      $_k : Int 5
+      $_v : Int 3
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_j : Int 0
-  				$_v : Int 2
-  				$_i : Int 6
-  				$_k : Int 6
+      $_i : Int 6
+      $_j : Int 0
+      $_k : Int 6
+      $_v : Int 2
+  Outcome: Returned (Val Loc 0)
+  Outcome: Returned (Val Loc 0)
+  Outcome: Assertion violated, counter example:
+      $_i : Int 6
+      $_j : Int 1
+      $_k : Int 6
+      $_v : Int 2
+  Outcome: Returned (Val Loc 0)
+  Outcome: Returned (Val Loc 0)
+  Outcome: Assertion violated, counter example:
+      $_i : Int 6
+      $_j : Int 2
+      $_k : Int 6
+      $_v : Int 3
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_j : Int 1
-  				$_k : Int 6
-  				$_i : Int 6
-  				$_v : Int 2
-  Outcome: Returned (Val Loc 0)
-  Outcome: Returned (Val Loc 0)
-  Outcome: Returned (Val Loc 0)
-  Outcome: Assertion violated, counter example:
-  				$_j : Int 2
-  				$_i : Int 6
-  				$_v : Int 3
-  				$_k : Int 6
-  Outcome: Returned (Val Loc 0)
-  Outcome: Returned (Val Loc 0)
+      $_i : Int 7
+      $_j : Int 0
+      $_k : Int 7
+      $_v : Int 2
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_j : Int 0
-  				$_v : Int 2
-  				$_k : Int 7
-  				$_i : Int 7
-  Outcome: Returned (Val Loc 0)
-  Outcome: Returned (Val Loc 0)
-  Outcome: Returned (Val Loc 0)
-  Outcome: Assertion violated, counter example:
-  				$_v : Int 2
-  				$_i : Int 7
-  				$_k : Int 7
-  				$_j : Int 1
-  Outcome: Returned (Val Loc 0)
+      $_i : Int 7
+      $_j : Int 1
+      $_k : Int 7
+      $_v : Int 2
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_j : Int 2
-  				$_i : Int 7
-  				$_v : Int 3
-  				$_k : Int 7
+      $_i : Int 7
+      $_j : Int 2
+      $_k : Int 7
+      $_v : Int 3
+  Outcome: Assumption evaluated to false
+  Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -3242,8 +3237,8 @@ Tests Model ArrayFork:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_y : Int 4
-  				$_x : Int 1
+      $_x : Int 1
+      $_y : Int 4
   Outcome: Returned (Val Int 0)
   Outcome: Returned (Val Int 0)
   Total number of files tested: 33

--- a/test/test_saf.t
+++ b/test/test_saf.t
@@ -12,7 +12,7 @@ Tests Model ArrayFork:
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 3
+      $_i : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   
@@ -24,29 +24,29 @@ Tests Model ArrayFork:
   Execution mode: saf
   
   Outcome: Assertion violated, counter example:
-      $_i : Int 0
-      $_v : Int 0
+      $_i : Int _
+      $_v : Int _
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 1
-      $_v : Int 1
+      $_i : Int _
+      $_v : Int _
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 2
-      $_v : Int 2
+      $_i : Int _
+      $_v : Int _
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 3
-      $_v : Int 3
+      $_i : Int _
+      $_v : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -503,10 +503,10 @@ Tests Model ArrayFork:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 22
+      $_i : Int _
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int -158
+      $_i : Int _
   
   =====================
   	Ænima
@@ -3089,68 +3089,68 @@ Tests Model ArrayFork:
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 5
-      $_j : Int 0
-      $_k : Int 5
-      $_v : Int 2
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 5
-      $_j : Int 1
-      $_k : Int 5
-      $_v : Int 2
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 5
-      $_j : Int 2
-      $_k : Int 5
-      $_v : Int 3
-  Outcome: Returned (Val Loc 0)
-  Outcome: Returned (Val Loc 0)
-  Outcome: Returned (Val Loc 0)
-  Outcome: Assertion violated, counter example:
-      $_i : Int 6
-      $_j : Int 0
-      $_k : Int 6
-      $_v : Int 2
-  Outcome: Returned (Val Loc 0)
-  Outcome: Returned (Val Loc 0)
-  Outcome: Assertion violated, counter example:
-      $_i : Int 6
-      $_j : Int 1
-      $_k : Int 6
-      $_v : Int 2
-  Outcome: Returned (Val Loc 0)
-  Outcome: Returned (Val Loc 0)
-  Outcome: Assertion violated, counter example:
-      $_i : Int 6
-      $_j : Int 2
-      $_k : Int 6
-      $_v : Int 3
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 7
-      $_j : Int 0
-      $_k : Int 7
-      $_v : Int 2
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 7
-      $_j : Int 1
-      $_k : Int 7
-      $_v : Int 2
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
   Outcome: Returned (Val Loc 0)
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 7
-      $_j : Int 2
-      $_k : Int 7
-      $_v : Int 3
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
+  Outcome: Returned (Val Loc 0)
+  Outcome: Returned (Val Loc 0)
+  Outcome: Returned (Val Loc 0)
+  Outcome: Assertion violated, counter example:
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
+  Outcome: Returned (Val Loc 0)
+  Outcome: Returned (Val Loc 0)
+  Outcome: Assertion violated, counter example:
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
+  Outcome: Returned (Val Loc 0)
+  Outcome: Returned (Val Loc 0)
+  Outcome: Assertion violated, counter example:
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -3237,8 +3237,8 @@ Tests Model ArrayFork:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_x : Int 1
-      $_y : Int 4
+      $_x : Int _
+      $_y : Int _
   Outcome: Returned (Val Int 0)
   Outcome: Returned (Val Int 0)
   Total number of files tested: 33

--- a/test/test_saite.t
+++ b/test/test_saite.t
@@ -10,7 +10,7 @@ Tests Model ArrayITE:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 3
+      $_i : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   
@@ -23,8 +23,8 @@ Tests Model ArrayITE:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 0
-      $_v : Int 0
+      $_i : Int _
+      $_v : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -439,10 +439,10 @@ Tests Model ArrayITE:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 22
+      $_i : Int _
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int -158
+      $_i : Int _
   
   =====================
   	Ænima
@@ -497,10 +497,10 @@ Tests Model ArrayITE:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 7
-      $_j : Int 0
-      $_k : Int 7
-      $_v : Int 2
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -545,8 +545,8 @@ Tests Model ArrayITE:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_x : Int 1
-      $_y : Int 4
+      $_x : Int _
+      $_y : Int _
   Outcome: Returned (Val Int 0)
   Outcome: Returned (Val Int 0)
   Total number of files tested: 33

--- a/test/test_saite.t
+++ b/test/test_saite.t
@@ -10,7 +10,7 @@ Tests Model ArrayITE:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 3
+      $_i : Int 3
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   
@@ -23,8 +23,8 @@ Tests Model ArrayITE:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 0
-  				$_v : Int 0
+      $_i : Int 0
+      $_v : Int 0
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -309,7 +309,8 @@ Tests Model ArrayITE:
   Input file: basic/common/3.wl
   Execution mode: saite
   
-  Outcome: Assertion violated, counter example:Empty model
+  Outcome: Assertion violated, counter example:
+      Empty model
   
   =====================
   	Ænima
@@ -345,7 +346,8 @@ Tests Model ArrayITE:
   Input file: basic/common/6.wl
   Execution mode: saite
   
-  Outcome: Assertion violated, counter example:Empty model
+  Outcome: Assertion violated, counter example:
+      Empty model
   
   =====================
   	Ænima
@@ -437,10 +439,10 @@ Tests Model ArrayITE:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 22
+      $_i : Int 22
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int -158
+      $_i : Int -158
   
   =====================
   	Ænima
@@ -495,10 +497,12 @@ Tests Model ArrayITE:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 5
-  				$_j : Int 0
-  				$_v : Int 2
-  				$_k : Int 5
+      $_i : Int 7
+      $_j : Int 0
+      $_k : Int 7
+      $_v : Int 2
+  Outcome: Assumption evaluated to false
+  Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -541,8 +545,8 @@ Tests Model ArrayITE:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_y : Int 4
-  				$_x : Int 1
+      $_x : Int 1
+      $_y : Int 4
   Outcome: Returned (Val Int 0)
   Outcome: Returned (Val Int 0)
   Total number of files tested: 33

--- a/test/test_sopl.t
+++ b/test/test_sopl.t
@@ -10,7 +10,7 @@ Tests Model WriteLists:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 3
+      $_i : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   
@@ -23,8 +23,8 @@ Tests Model WriteLists:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 0
-      $_v : Int 0
+      $_i : Int _
+      $_v : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -439,10 +439,10 @@ Tests Model WriteLists:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 22
+      $_i : Int _
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int -158
+      $_i : Int _
   
   =====================
   	Ænima
@@ -497,10 +497,10 @@ Tests Model WriteLists:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 5
-      $_j : Int 2
-      $_k : Int 5
-      $_v : Int 6
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -545,8 +545,8 @@ Tests Model WriteLists:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_x : Int 1
-      $_y : Int 4
+      $_x : Int _
+      $_y : Int _
   Outcome: Returned (Val Int 0)
   Outcome: Returned (Val Int 0)
   Total number of files tested: 33

--- a/test/test_sopl.t
+++ b/test/test_sopl.t
@@ -10,7 +10,7 @@ Tests Model WriteLists:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 3
+      $_i : Int 3
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   
@@ -23,8 +23,8 @@ Tests Model WriteLists:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 0
-  				$_v : Int 0
+      $_i : Int 0
+      $_v : Int 0
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -309,7 +309,8 @@ Tests Model WriteLists:
   Input file: basic/common/3.wl
   Execution mode: sopl
   
-  Outcome: Assertion violated, counter example:Empty model
+  Outcome: Assertion violated, counter example:
+      Empty model
   
   =====================
   	Ænima
@@ -345,7 +346,8 @@ Tests Model WriteLists:
   Input file: basic/common/6.wl
   Execution mode: sopl
   
-  Outcome: Assertion violated, counter example:Empty model
+  Outcome: Assertion violated, counter example:
+      Empty model
   
   =====================
   	Ænima
@@ -437,10 +439,10 @@ Tests Model WriteLists:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 22
+      $_i : Int 22
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int -158
+      $_i : Int -158
   
   =====================
   	Ænima
@@ -495,10 +497,12 @@ Tests Model WriteLists:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 5
-  				$_k : Int 5
-  				$_v : Int 6
-  				$_j : Int 2
+      $_i : Int 5
+      $_j : Int 2
+      $_k : Int 5
+      $_v : Int 6
+  Outcome: Assumption evaluated to false
+  Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -541,8 +545,8 @@ Tests Model WriteLists:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_y : Int 4
-  				$_x : Int 1
+      $_x : Int 1
+      $_y : Int 4
   Outcome: Returned (Val Int 0)
   Outcome: Returned (Val Int 0)
   Total number of files tested: 33

--- a/test/test_st.t
+++ b/test/test_st.t
@@ -10,7 +10,7 @@ Tests Model Tree:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 3
+      $_i : Int 3
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   
@@ -23,8 +23,8 @@ Tests Model Tree:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 0
-  				$_v : Int 0
+      $_i : Int 0
+      $_v : Int 0
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -311,7 +311,8 @@ Tests Model Tree:
   Input file: basic/common/3.wl
   Execution mode: st
   
-  Outcome: Assertion violated, counter example:Empty model
+  Outcome: Assertion violated, counter example:
+      Empty model
   
   =====================
   	Ænima
@@ -347,7 +348,8 @@ Tests Model Tree:
   Input file: basic/common/6.wl
   Execution mode: st
   
-  Outcome: Assertion violated, counter example:Empty model
+  Outcome: Assertion violated, counter example:
+      Empty model
   
   =====================
   	Ænima
@@ -439,10 +441,10 @@ Tests Model Tree:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int 22
+      $_i : Int 22
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_i : Int -158
+      $_i : Int -158
   
   =====================
   	Ænima
@@ -497,10 +499,12 @@ Tests Model Tree:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-  				$_k : Int 6
-  				$_v : Int 8
-  				$_j : Int 2
-  				$_i : Int 6
+      $_i : Int 6
+      $_j : Int 2
+      $_k : Int 6
+      $_v : Int 7
+  Outcome: Assumption evaluated to false
+  Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -543,8 +547,8 @@ Tests Model Tree:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-  				$_y : Int 4
-  				$_x : Int 1
+      $_x : Int 1
+      $_y : Int 4
   Outcome: Returned (Val Int 0)
   Outcome: Returned (Val Int 0)
   Total number of files tested: 33

--- a/test/test_st.t
+++ b/test/test_st.t
@@ -10,7 +10,7 @@ Tests Model Tree:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 3
+      $_i : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   
@@ -23,8 +23,8 @@ Tests Model Tree:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 0
-      $_v : Int 0
+      $_i : Int _
+      $_v : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -441,10 +441,10 @@ Tests Model Tree:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 22
+      $_i : Int _
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int -158
+      $_i : Int _
   
   =====================
   	Ænima
@@ -499,10 +499,10 @@ Tests Model Tree:
   
   Outcome: Returned (Val Loc 0)
   Outcome: Assertion violated, counter example:
-      $_i : Int 6
-      $_j : Int 2
-      $_k : Int 6
-      $_v : Int 7
+      $_i : Int _
+      $_j : Int _
+      $_k : Int _
+      $_v : Int _
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
   Outcome: Assumption evaluated to false
@@ -547,8 +547,8 @@ Tests Model Tree:
   
   Outcome: Returned (Val Int 0)
   Outcome: Assertion violated, counter example:
-      $_x : Int 1
-      $_y : Int 4
+      $_x : Int _
+      $_y : Int _
   Outcome: Returned (Val Int 0)
   Outcome: Returned (Val Int 0)
   Total number of files tested: 33


### PR DESCRIPTION
Closes #10 with same solution as formalsec/encoding#72:
- Print `_` instead of a concrete value in the stdout model, emulating a non-deterministic value matching expect test. 

